### PR TITLE
Glue together desktop flow

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -390,10 +390,8 @@ const CONST = {
     // Use Environment.getEnvironmentURL to get the complete URL with port number
     DEV_NEW_EXPENSIFY_URL: 'http://localhost:',
 
-    APPLE_SIGN_IN_SERVICE_ID: 'com.expensify.expensifylite.AppleSignIn',
-    APPLE_SIGN_IN_REDIRECT_URI: 'https://www.expensify.com/partners/apple/loginCallback',
-    // APPLE_SIGN_IN_SERVICE_ID: 'com.chat.expensify.chat.AppleSignIn',
-    // APPLE_SIGN_IN_REDIRECT_URI: 'https://new.expensify.com/appleauth',
+    APPLE_SIGN_IN_SERVICE_ID: 'com.chat.expensify.chat.AppleSignIn',
+    APPLE_SIGN_IN_REDIRECT_URI: 'https://new.expensify.com/appleauth',
 
     OPTION_TYPE: {
         REPORT: 'report',

--- a/src/components/SignInButtons/AppleSignIn/index.website.js
+++ b/src/components/SignInButtons/AppleSignIn/index.website.js
@@ -7,6 +7,7 @@ import getUserLanguage from '../GetUserLanguage';
 import * as Session from '../../../libs/actions/Session';
 import Log from '../../../libs/Log';
 import * as Environment from '../../../libs/Environment/Environment';
+import CONST from '../../../CONST';
 
 // TODO: copied from CONFIG.js, refactor
 // react-native-config doesn't trim whitespace on iOS for some reason so we
@@ -24,17 +25,11 @@ const defaultProps = {
     isDesktopFlow: false,
 };
 
-// TODO: move to appropriate consts file
-const defaultClientId = 'com.expensify.expensifylite.AppleSignIn';
-// const defaultClientId = 'com.chat.expensify.chat.AppleSignIn';
-const defaultRedirectURI = 'https://www.expensify.com/partners/apple/loginCallback';
-// const defaultRedirectURI = 'https://new.expensify.com/appleauth';
-
 const config = {
-    clientId: lodashGet(Config, 'ASI_CLIENTID_OVERRIDE', defaultClientId),
+    clientId: lodashGet(Config, 'ASI_CLIENTID_OVERRIDE', CONST.APPLE_SIGN_IN_SERVICE_ID),
     scope: 'name email',
     // never used, but required for configuration
-    redirectURI: lodashGet(Config, 'ASI_REDIRECTURI_OVERRIDE', defaultRedirectURI),
+    redirectURI: lodashGet(Config, 'ASI_REDIRECTURI_OVERRIDE', CONST.APPLE_SIGN_IN_REDIRECT_URI),
     state: '',
     nonce: '',
     usePopup: true,

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -222,7 +222,6 @@ export default {
         },
     },
     thirdPartySignIn: {
-        or: 'Or',
         alreadySignedIn: ({email}) => `You are already signed in as ${email}.`,
         goBackMessage: ({provider}) => `Don't want to sign in with ${provider}?`,
         continueWithMyCurrentSession: 'Continue with my current session',

--- a/src/pages/signin/AppleSignInDesktopPage/index.website.js
+++ b/src/pages/signin/AppleSignInDesktopPage/index.website.js
@@ -1,32 +1,8 @@
 import React from 'react';
-import {View} from 'react-native';
-import AppleSignIn from '../../../components/SignInButtons/AppleSignIn';
+import ThirdPartySignInPage from '../ThirdPartySignInPage';
 
-/* Dedicated screen that the desktop app links to on the web app, as Apple/Google
- * sign-in cannot work fully within Electron, so we escape to web and redirect
- * to desktop once we have an Expensify auth token.
- */
 function AppleSignInDesktopPage() {
-    return (
-        <View
-            style={{
-                height: '100%',
-                width: '100%',
-                justifyContent: 'center',
-                alignItems: 'center',
-            }}
-        >
-            <View
-                style={{
-                    flexDirection: 'row',
-                    width: '100%',
-                    justifyContent: 'center',
-                }}
-            >
-                <AppleSignIn isDesktopFlow />
-            </View>
-        </View>
-    );
+    return <ThirdPartySignInPage signInProvider="apple" />;
 }
 
 export default AppleSignInDesktopPage;

--- a/src/pages/signin/ThirdPartySignInPage.js
+++ b/src/pages/signin/ThirdPartySignInPage.js
@@ -1,42 +1,18 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import {withOnyx} from 'react-native-onyx';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import ONYXKEYS from '../../ONYXKEYS';
 import styles from '../../styles/styles';
 import compose from '../../libs/compose';
 import SignInPageLayout from './SignInPageLayout';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
-import Performance from '../../libs/Performance';
-import * as App from '../../libs/actions/App';
 import Text from '../../components/Text';
 import TextLink from '../../components/TextLink';
 import Button from '../../components/Button';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/withWindowDimensions';
-import * as Localize from '../../libs/Localize';
 import ROUTES from '../../ROUTES';
 import Navigation from '../../libs/Navigation/Navigation';
 
 const propTypes = {
-    /* Onyx Props */
-
-    /** The details about the account that the user is signing in with */
-    account: PropTypes.shape({
-        /** Error to display when there is an account error returned */
-        errors: PropTypes.objectOf(PropTypes.string),
-
-        /** Whether the account is validated */
-        validated: PropTypes.bool,
-
-        /** The primaryLogin associated with the account */
-        primaryLogin: PropTypes.string,
-    }),
-
-    /** List of betas available to current user */
-    betas: PropTypes.arrayOf(PropTypes.string),
-
-    credentials: PropTypes.objectOf(PropTypes.string),
-
     signInProvider: PropTypes.oneOf(['google', 'apple']),
 
     ...withLocalizePropTypes,
@@ -45,30 +21,19 @@ const propTypes = {
 };
 
 const defaultProps = {
-    account: {},
-    betas: [],
-    credentials: {},
     signInProvider: 'google',
 };
 
 const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
 
+/* Dedicated screen that the desktop app links to on the web app, as Apple/Google
+ * sign-in cannot work fully within Electron, so we escape to web and redirect
+ * to desktop once we have an Expensify auth token.
+ */
 function ThirdPartySignInPage(props) {
-    useEffect(() => {
-        Performance.measureTTI();
-
-        App.setLocale(Localize.getDevicePreferredLocale());
-    }, []);
-
-    const continueWithCurrentSession = () => {
-        console.log('ContinueWithCurrentSession');
-    };
-
     const goBack = () => {
         Navigation.navigate(ROUTES.HOME);
     };
-
-    window.account = props.account;
 
     return (
         <SafeAreaView style={[styles.signInPage]}>
@@ -76,19 +41,12 @@ function ThirdPartySignInPage(props) {
                 welcomeHeader={props.translate('welcomeText.getStarted')}
                 shouldShowWelcomeHeader
             >
-                <Text style={[styles.mb5]}>{props.translate('thirdPartySignIn.alreadySignedIn', {email: 'johndoe@example.com'})}</Text>
-                <Button
-                    large
-                    text={props.translate('thirdPartySignIn.continueWithMyCurrentSession')}
-                    onPress={continueWithCurrentSession}
-                />
-                <Text style={[styles.mb5, styles.mt5]}>{props.translate('thirdPartySignIn.or')}</Text>
                 {props.signInProvider === 'google' && (
                     <Button
                         large
                         text="Continue with Google"
                         style={[styles.mb5]}
-                        onPress={continueWithCurrentSession}
+                        onPress={() => {}}
                     />
                 )}
                 <Text style={[styles.mt5]}>{props.translate('thirdPartySignIn.redirectToDesktopMessage')}</Text>
@@ -125,12 +83,4 @@ ThirdPartySignInPage.propTypes = propTypes;
 ThirdPartySignInPage.defaultProps = defaultProps;
 ThirdPartySignInPage.displayName = 'ThirdPartySignInPage';
 
-export default compose(
-    withLocalize,
-    withWindowDimensions,
-    withOnyx({
-        account: {key: ONYXKEYS.ACCOUNT},
-        betas: {key: ONYXKEYS.BETAS},
-        credentials: {key: ONYXKEYS.CREDENTIALS},
-    }),
-)(ThirdPartySignInPage);
+export default compose(withLocalize, withWindowDimensions)(ThirdPartySignInPage);

--- a/src/pages/signin/ThirdPartySignInPage.js
+++ b/src/pages/signin/ThirdPartySignInPage.js
@@ -7,21 +7,17 @@ import SignInPageLayout from './SignInPageLayout';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
 import Text from '../../components/Text';
 import TextLink from '../../components/TextLink';
-import Button from '../../components/Button';
+import AppleSignIn from '../../components/SignInButtons/AppleSignIn';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/withWindowDimensions';
 import ROUTES from '../../ROUTES';
 import Navigation from '../../libs/Navigation/Navigation';
 
 const propTypes = {
-    signInProvider: PropTypes.oneOf(['google', 'apple']),
+    signInProvider: PropTypes.oneOf(['google', 'apple']).isRequired,
 
     ...withLocalizePropTypes,
 
     ...windowDimensionsPropTypes,
-};
-
-const defaultProps = {
-    signInProvider: 'google',
 };
 
 const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
@@ -41,14 +37,7 @@ function ThirdPartySignInPage(props) {
                 welcomeHeader={props.translate('welcomeText.getStarted')}
                 shouldShowWelcomeHeader
             >
-                {props.signInProvider === 'google' && (
-                    <Button
-                        large
-                        text="Continue with Google"
-                        style={[styles.mb5]}
-                        onPress={() => {}}
-                    />
-                )}
+                {props.signInProvider === 'apple' ? <AppleSignIn isDesktopFlow /> : null}
                 <Text style={[styles.mt5]}>{props.translate('thirdPartySignIn.redirectToDesktopMessage')}</Text>
                 <Text style={[styles.mt5]}>{props.translate('thirdPartySignIn.goBackMessage', {provider: capitalize(props.signInProvider)})}</Text>
                 <TextLink
@@ -80,7 +69,6 @@ function ThirdPartySignInPage(props) {
 }
 
 ThirdPartySignInPage.propTypes = propTypes;
-ThirdPartySignInPage.defaultProps = defaultProps;
 ThirdPartySignInPage.displayName = 'ThirdPartySignInPage';
 
 export default compose(withLocalize, withWindowDimensions)(ThirdPartySignInPage);


### PR DESCRIPTION
Glued together the desktop flow. There's still cleanup to do, but the flow is working.

Additionally, did some cleanup of unused code, and corrected the Android and web buttons to be using the new Apple sign-in config.

### Demos

I've included two videos that also show the configuration changes I made (not including running the appropriate ngrok tunnel for the first half of the test).

First half of test: Apple pop-up works, returns a token
Requires:
* HTTPS ssh tunnel
* Custom Apple config using the HTTPS ssh tunnel domain

Video:

https://github.com/infinitered/ExpensifyApp/assets/5252268/a56dbdbc-f84a-4c6b-90c3-4dcff2cd195d

I got a 429 response there, which is unexpected, but okay: I don't expect the API call to succeed since the token doesn't match Expensify's Apple auth config. I would've expected a 666 response (https://infinitered.slack.com/archives/C04KQL2HSQ1/p1685035198781549?thread_ts=1684523854.322939&cid=C04KQL2HSQ1). This might be an issue with SSH tunneling and web proxying to the API.

Second half of test: the page, given a token, will log the user in and offer to redirect them to the desktop app
Requires:
* A valid Expensify/Apple token hardcoded into the action (easiest to get from the Android flow while using the Expensify Apple auth config)

Video:

https://github.com/infinitered/ExpensifyApp/assets/5252268/3c324e1a-9023-4b93-ae3c-ce3983fe3bdf

## Next up

This flow is a high priority for testing in staging and prod. Particularly, that:
1. The desktop button opens the correct page on the website
2. The web page generates a token and passes it back to the desktop app successfully (i.e., testing that the deeplinking config on staging/prod builds of the desktop app is correct, as it isn't fully testable for us in dev)

### TODOs

These can be done on cleanup task as needed:

- [ ] Fix naming: I don't love `ThirdPartySignInPage` when it's a component/template, and I'd love to more clearly indicate it's only for the desktop flow. `AppleGoogleSignInDesktopTemplate` is pretty wordy though 😄 
- [ ] Does the privacy policy copy really need to be there? it isn't on the main login form
- [ ] thirdpartysigninpage needs to be website-only, because it uses props on sign-in button that are website-only
- [ ] note that clicking "go back" doesn't seem to store the SIWA route in history, can't use browser to go back to it afterwards
- [ ] I did not get chance to re-assess env var flow for testing; feel free to remove that, but also update the testing instructions accordingly