### PR TITLE
[WIP] iOS state sharing POC

### DIFF
--- a/index.share.js
+++ b/index.share.js
@@ -9,17 +9,29 @@
 //   () => MyShareComponent
 // );
 import 'react-native-gesture-handler';
-import {AppRegistry} from 'react-native';
-import DotIndicatorMessage from './src/components/DotIndicatorMessage'
-import styles from './src/styles/styles'
+import {AppRegistry, View, Text} from 'react-native';
+import Onyx, {withOnyx} from 'react-native-onyx';
+import ONYXKEYS from './src/ONYXKEYS';
 
-function TestEntry () {
+
+const config = {
+    keys: ONYXKEYS,
+};
+
+Onyx.init(config);
+Onyx.set(ONYXKEYS.ACCOUNT, {accountname: "myaccount"});
+
+function BasicOnyxComponent(props) {
+   return <View style={{flex: 1}}><Text>{JSON.stringify(props.account)}</Text><Text>Test string</Text></View>
+}
+
+const WithHOC = withOnyx({account: {key: ONYXKEYS.ACCOUNT}})(BasicOnyxComponent)
+
+function TestEntry() {
   return (
-                    <DotIndicatorMessage
-                        style={[styles.mv2]}
-                        type="success"
-                        messages={{0: 'hello'}}
-                    />
+    <View style={{flex: 1, backgroundColor: 'yellow'}}>
+      <WithHOC />
+    </View>
   )
 }
 

--- a/index.share.js
+++ b/index.share.js
@@ -1,10 +1,26 @@
-import { AppRegistry, View, Text } from "react-native";
+// import { AppRegistry, View, Text } from "react-native";
+// 
+// function MyShareComponent() {
+//   return <View><Text>Rendered share component!</Text></View>
+// }
+// 
+// AppRegistry.registerComponent(
+//   "ShareMenuModuleComponent",
+//   () => MyShareComponent
+// );
+import 'react-native-gesture-handler';
+import {AppRegistry} from 'react-native';
+import DotIndicatorMessage from './src/components/DotIndicatorMessage'
+import styles from './src/styles/styles'
 
-function MyShareComponent() {
-  return <View><Text>Rendered share component!</Text></View>
+function TestEntry () {
+  return (
+                    <DotIndicatorMessage
+                        style={[styles.mv2]}
+                        type="success"
+                        messages={{0: 'hello'}}
+                    />
+  )
 }
 
-AppRegistry.registerComponent(
-  "ShareMenuModuleComponent",
-  () => MyShareComponent
-);
+AppRegistry.registerComponent("ShareMenuModuleComponent", () => TestEntry);

--- a/ios/NewExpensify.xcodeproj/project.pbxproj
+++ b/ios/NewExpensify.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		BDB853621F354EBB84E619C2 /* ExpensifyNewKansas-MediumItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = D2AFB39EC1D44BF9B91D3227 /* ExpensifyNewKansas-MediumItalic.otf */; };
 		C5288D8521EC45B7AE5D7D1B /* libPods-NewExpensify-share.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9903BDDB74AF1D4C4694443E /* libPods-NewExpensify-share.a */; };
 		DD79042B2792E76D004484B4 /* RCTBootSplash.m in Sources */ = {isa = PBXBuildFile; fileRef = DD79042A2792E76D004484B4 /* RCTBootSplash.m */; };
-		E51DC681C7DEE40AEBDDFBFE /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+		E51DC681C7DEE40AEBDDFBFE /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		E9DF872D2525201700607FDC /* AirshipConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = E9DF872C2525201700607FDC /* AirshipConfig.plist */; };
 		ED222ED90E074A5481A854FA /* ExpensifyNeue-BoldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 8B28D84EF339436DBD42A203 /* ExpensifyNeue-BoldItalic.otf */; };
 		F0C450EA2705020500FD2970 /* colors.json in Resources */ = {isa = PBXBuildFile; fileRef = F0C450E92705020500FD2970 /* colors.json */; };
@@ -136,7 +136,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E51DC681C7DEE40AEBDDFBFE /* (null) in Frameworks */,
+				E51DC681C7DEE40AEBDDFBFE /* BuildFile in Frameworks */,
 				9A65F0F374EC04ABB5FF40AF /* libPods-NewExpensify.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
This is a proof-of-concept and should not be considered final code.

Exploration of how we can share state necessary to be authenticated and post to the Expensify API from within the share extension.

Confirmed so far:

- [x] Whether just importing the `App` component works (it does not, and there's no clear error message)
- [x] Can import display-only components from Expensify and show them in the share extension
- [x] Can use the  

To confirm:

## Onyx

- [ ] Onyx on iOS is backed by a SQLite DB with a constant name:  https://github.com/Expensify/react-native-onyx/blob/main/lib/storage/providers/SQLiteStorage.js#L8. If we can store this in a place where both the main app and share extension could access it, we can share it. How would we do this?
- [ ] Test authentication state sharing by logging into main app then showing authToken inside share extension (I believe this is just Onyx-based, but not sure)

## API/Pusher

- [ ] find a test command we can use to easily check if the API integration is working

## Code sharing

Code sharing-related questions, between iOS app and share extension:

### Native code

- [ ] It looks like the Share extension is being auto-linked with all dependencies. Confirm if this is true by trying to use a native-backed dependency in the share extension.

### Assets

- [ ] Many screens use SVGs or other assets. How can we share assets between the two?

## General

### Development

- [ ] Are there any blockers in app state setup that can't be run in the share extension right now?
- [ ] What debugging tools can we use with the share extension? (Flipper/RN Profiler, native logs, native debugger)