### PR TITLE
iOS: support arbitrary files

### DIFF
--- a/ios/NewExpensify.xcodeproj/project.pbxproj
+++ b/ios/NewExpensify.xcodeproj/project.pbxproj
@@ -46,7 +46,7 @@
 		BDB853621F354EBB84E619C2 /* ExpensifyNewKansas-MediumItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = D2AFB39EC1D44BF9B91D3227 /* ExpensifyNewKansas-MediumItalic.otf */; };
 		C5288D8521EC45B7AE5D7D1B /* libPods-NewExpensify-share.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9903BDDB74AF1D4C4694443E /* libPods-NewExpensify-share.a */; };
 		DD79042B2792E76D004484B4 /* RCTBootSplash.m in Sources */ = {isa = PBXBuildFile; fileRef = DD79042A2792E76D004484B4 /* RCTBootSplash.m */; };
-		E51DC681C7DEE40AEBDDFBFE /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+		E51DC681C7DEE40AEBDDFBFE /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		E9DF872D2525201700607FDC /* AirshipConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = E9DF872C2525201700607FDC /* AirshipConfig.plist */; };
 		ED222ED90E074A5481A854FA /* ExpensifyNeue-BoldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 8B28D84EF339436DBD42A203 /* ExpensifyNeue-BoldItalic.otf */; };
 		F0C450EA2705020500FD2970 /* colors.json in Resources */ = {isa = PBXBuildFile; fileRef = F0C450E92705020500FD2970 /* colors.json */; };
@@ -149,7 +149,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E51DC681C7DEE40AEBDDFBFE /* (null) in Frameworks */,
+				E51DC681C7DEE40AEBDDFBFE /* BuildFile in Frameworks */,
 				9A65F0F374EC04ABB5FF40AF /* libPods-NewExpensify.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/share/Info.plist
+++ b/ios/share/Info.plist
@@ -25,6 +25,8 @@
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<dict>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<string>1</string>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
 				<integer>1</integer>
 				<key>NSExtensionActivationSupportsText</key>


### PR DESCRIPTION
Need to add another rule to match design doc and support arbitrary files.

However, this isn't working quite yet; the files I tested with are all returning a mimeType of "text/plain", so the URL is being added to the message instead of the file being added as an attachment. Data example from a simulator test:

```
  "data": [
    {
      "data": "file:///Users/lizzi/Library/Developer/CoreSimulator/Devices/F4ED2C23-6DD0-4C55-842A-9253180D4119/data/Containers/Shared/AppGroup/8F6E97D2-E225-4B0F-9007-16E169008498/File%20Provider%20Storage/C_harmonic.ogg",
      "mimeType": "text/plain"
    }
  ]
```

Seems likely to be a bug in the react-native-share-menu iOS code.