### PR TITLE
Lindboe/share message page UI

### DIFF
--- a/src/pages/ShareMessagePage.js
+++ b/src/pages/ShareMessagePage.js
@@ -13,6 +13,7 @@ import Navigation from '../libs/Navigation/Navigation';
 import Share from '../libs/Share';
 import * as Report from '../libs/actions/Report';
 import styles from '../styles/styles';
+import FixedFooter from '../components/FixedFooter';
 
 function ShareMessagePage(props) {
     const reportID = props.route.params.reportID;
@@ -30,48 +31,52 @@ function ShareMessagePage(props) {
                 title={props.translate('newChatPage.shareToExpensify')}
                 onCloseButtonPress={Share.dismiss}
             />
-            <Text style={[styles.textLabelSupporting, {paddingLeft: 24}]}>{props.translate('common.to')}</Text>
-            <OptionRowLHNData
-                onSelectRow={Navigation.goBack}
-                reportID={reportID}
-            />
-            <View style={{padding: 24}}>
-                <TextInput
-                    accessibilityLabel={props.translate('common.message')}
-                    label={props.translate('common.message')}
-                    accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
-                    autoGrowHeight
-                    textAlignVertical="top"
-                    containerStyles={[styles.autoGrowHeightMultilineInput]}
-                    submitOnEnter={false}
-                    onChangeText={setMessage}
-                    value={message}
-                />
-            </View>
-            {!isTextShare && (
-                <View style={{padding: 24}}>
-                    <Text style={styles.textLabelSupporting}>{props.translate('common.share')}</Text>
-                    {!!share.source && (
-                        <View style={{borderRadius: 8, height: 200, marginTop: 8, overflow: 'hidden', width: '100%'}}>
-                            <AttachmentView source={share.source} />
+            <View style={[styles.justifyContentBetween, styles.flexGrow1]}>
+                <View>
+                    <Text style={[styles.textLabelSupporting, {paddingLeft: 24}]}>{props.translate('common.to')}</Text>
+                    <OptionRowLHNData
+                        onSelectRow={Navigation.goBack}
+                        reportID={reportID}
+                    />
+                    <View style={{padding: 24}}>
+                        <TextInput
+                            accessibilityLabel={props.translate('common.message')}
+                            label={props.translate('common.message')}
+                            accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
+                            autoGrowHeight
+                            textAlignVertical="top"
+                            containerStyles={[styles.autoGrowHeightMultilineInput]}
+                            submitOnEnter={false}
+                            onChangeText={setMessage}
+                            value={message}
+                        />
+                    </View>
+                    {!isTextShare && (
+                        <View style={{padding: 24}}>
+                            <Text style={styles.textLabelSupporting}>{props.translate('common.share')}</Text>
+                            {!!share.source && (
+                                <View style={{borderRadius: 8, height: 200, marginTop: 8, overflow: 'hidden', width: '100%'}}>
+                                    <AttachmentView source={share.source} />
+                                </View>
+                            )}
                         </View>
                     )}
                 </View>
-            )}
-            <View style={{padding: 24}}>
-                <Button
-                    success
-                    pressOnEnter
-                    text={props.translate('common.share')}
-                    onPress={() => {
-                        if (isTextShare) {
-                            Report.addComment(reportID, message);
-                        } else {
-                            Report.addAttachment(reportID, share, message);
-                        }
-                        Share.dismiss();
-                    }}
-                />
+                <FixedFooter>
+                    <Button
+                        success
+                        pressOnEnter
+                        text={props.translate('common.share')}
+                        onPress={() => {
+                            if (isTextShare) {
+                                Report.addComment(reportID, message);
+                            } else {
+                                Report.addAttachment(reportID, share, message);
+                            }
+                            Share.dismiss();
+                        }}
+                    />
+                </FixedFooter>
             </View>
         </ScreenWrapper>
     );

--- a/src/pages/ShareMessagePage.js
+++ b/src/pages/ShareMessagePage.js
@@ -37,9 +37,13 @@ function ShareMessagePage(props) {
             />
             <View style={{padding: 24}}>
                 <TextInput
-                    accessibilityLabel={props.translate(isTextShare ? 'common.share' : 'moneyRequestConfirmationList.whatsItFor')}
+                    accessibilityLabel={props.translate('common.message')}
+                    label={props.translate('common.message')}
                     accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
-                    label={props.translate(isTextShare ? 'common.share' : 'moneyRequestConfirmationList.whatsItFor')}
+                    autoGrowHeight
+                    textAlignVertical="top"
+                    containerStyles={[styles.autoGrowHeightMultilineInput]}
+                    submitOnEnter={false}
                     onChangeText={setMessage}
                     value={message}
                 />


### PR DESCRIPTION
Adds multiline input and updates the ShareMessagePage to be closer to the intended design (mostly done for my ease of screenshotting).

The layout changes are based on NewChatPage, but it's still not quite right; the button is partially hidden under the keyboard on iOS, but Android works correctly.

iOS
<img width="405" alt="Screenshot 2023-08-07 at 9 55 51 PM" src="https://github.com/infinitered/ExpensifyApp/assets/5252268/09556802-f094-4a36-97b9-bbf6becf80ea">

Android
<img width="409" alt="Screenshot 2023-08-07 at 9 58 32 PM" src="https://github.com/infinitered/ExpensifyApp/assets/5252268/32ae9ca1-7404-4a79-b2d4-d2703392be2f">
