### PR TITLE
Remove splash screen and update color

### DIFF
--- a/ios/share/Base.lproj/MainInterface.storyboard
+++ b/ios/share/Base.lproj/MainInterface.storyboard
@@ -14,23 +14,11 @@
                     <view key="view" autoresizesSubviews="NO" userInteractionEnabled="NO" contentMode="scaleToFill" id="I1y-SQ-EVP">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <subviews>
-                            <imageView autoresizesSubviews="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="BootSplashLogo" translatesAutoresizingMaskIntoConstraints="NO" id="sni-Mb-ofs">
-                                <rect key="frame" x="146.66666666666666" y="376" width="100" height="100"/>
-                                <accessibility key="accessibilityConfiguration">
-                                    <accessibilityTraits key="traits" image="YES" notEnabled="YES"/>
-                                </accessibility>
-                            </imageView>
-                        </subviews>
                         <viewLayoutGuide key="safeArea" id="w5B-xv-ZCf"/>
-                        <color key="backgroundColor" red="0.01176470588" green="0.83137254900000002" blue="0.48627450979999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" red="0.027450980390000001" green="0.1529411765" blue="0.1215686275" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <accessibility key="accessibilityConfiguration">
                             <accessibilityTraits key="traits" notEnabled="YES"/>
                         </accessibility>
-                        <constraints>
-                            <constraint firstItem="sni-Mb-ofs" firstAttribute="centerY" secondItem="I1y-SQ-EVP" secondAttribute="centerY" id="UZ5-Yb-N44"/>
-                            <constraint firstItem="sni-Mb-ofs" firstAttribute="centerX" secondItem="I1y-SQ-EVP" secondAttribute="centerX" id="mu8-Mc-ETf"/>
-                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CEy-Cv-SGf" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -38,7 +26,4 @@
             <point key="canvasLocation" x="-18" y="-27"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="BootSplashLogo" width="100" height="100"/>
-    </resources>
 </document>

--- a/patches/react-native-share-menu+6.0.0.patch
+++ b/patches/react-native-share-menu+6.0.0.patch
@@ -179,7 +179,7 @@ index e290cce..1c114ff 100644
 +
  }
 diff --git a/node_modules/react-native-share-menu/ios/ReactShareViewController.swift b/node_modules/react-native-share-menu/ios/ReactShareViewController.swift
-index f42bce6..ab00813 100644
+index f42bce6..d31fac9 100644
 --- a/node_modules/react-native-share-menu/ios/ReactShareViewController.swift
 +++ b/node_modules/react-native-share-menu/ios/ReactShareViewController.swift
 @@ -13,7 +13,7 @@ class ReactShareViewController: ShareViewController, RCTBridgeDelegate, ReactSha
@@ -191,7 +191,7 @@ index f42bce6..ab00813 100644
  #else
      return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
  #endif
-@@ -29,20 +29,7 @@ class ReactShareViewController: ShareViewController, RCTBridgeDelegate, ReactSha
+@@ -29,21 +29,6 @@ class ReactShareViewController: ShareViewController, RCTBridgeDelegate, ReactSha
        initialProperties: nil
      )
  
@@ -209,10 +209,10 @@ index f42bce6..ab00813 100644
 -
 -      rootView.backgroundColor = UIColor(red: CGFloat(red), green: CGFloat(green), blue: CGFloat(blue), alpha: CGFloat(alpha))
 -    }
-+    RCTBootSplash.initWithStoryboard("MainInterface", rootView: rootView)
- 
+-
      self.view = rootView
  
+     ShareMenuReactView.attachViewDelegate(self)
 diff --git a/node_modules/react-native-share-menu/ios/ShareViewController.swift b/node_modules/react-native-share-menu/ios/ShareViewController.swift
 index 12d8c92..0d84f19 100644
 --- a/node_modules/react-native-share-menu/ios/ShareViewController.swift

--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -103,7 +103,7 @@ function Expensify(props) {
 
     const isAuthenticated = useMemo(() => Boolean(lodashGet(props.session, 'authToken', null)), [props.session]);
     const shouldInit = isNavigationReady && (!isAuthenticated || props.isSidebarLoaded) && hasAttemptedToOpenPublicRoom;
-    const shouldHideSplash = shouldInit && !isSplashHidden;
+    const shouldHideSplash = shouldInit && !isSplashHidden && !Share.isShareExtension;
 
     const initializeClient = () => {
         if (!Visibility.isVisible()) {


### PR DESCRIPTION
Updates to remove the native screen implementation and not show the JS splash screen in the share app.

https://github.com/infinitered/ExpensifyApp/assets/8878532/81f53ffe-6ea7-4ca2-8037-c4bfc5874474

