### PR TITLE
Update Handing of kUTType's and Mimetypes within RNSM

### DIFF
--- a/ios/share/Info.plist
+++ b/ios/share/Info.plist
@@ -25,6 +25,8 @@
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<dict>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<string>1</string>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
 				<integer>1</integer>
 				<key>NSExtensionActivationSupportsText</key>

--- a/patches/react-native-share-menu+6.0.0.patch
+++ b/patches/react-native-share-menu+6.0.0.patch
@@ -88,7 +88,7 @@ index e8e1b73..bdd4d79 100644
  
  export default {
 diff --git a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
-index e290cce..775957d 100644
+index e290cce..1df000a 100644
 --- a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
 +++ b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
 @@ -18,8 +18,6 @@ public class ShareMenuReactView: NSObject {
@@ -112,6 +112,42 @@ index e290cce..775957d 100644
      @objc(dismissExtension:)
      func dismissExtension(_ error: String?) {
          guard let extensionContext = ShareMenuReactView.viewDelegate?.loadExtensionContext() else {
+@@ -106,11 +109,17 @@ public class ShareMenuReactView: NSObject {
+                 }
+ 
+                 for provider in attachments {
+-                    if provider.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
+-                        provider.loadItem(forTypeIdentifier: kUTTypeURL as String, options: nil) { (item, error) in
++                    var info = provider.registeredTypeIdentifiers
++                    var isImage = provider.hasItemConformingToTypeIdentifier("public.image")
++                    var isFileUrl = provider.hasItemConformingToTypeIdentifier("public.file-url")
++                    var isUrl = provider.hasItemConformingToTypeIdentifier("public.url")
++                    var isText = provider.hasItemConformingToTypeIdentifier("public.text")
++                    
++                    if provider.hasItemConformingToTypeIdentifier(kUTTypeData as String) {
++                        provider.loadItem(forTypeIdentifier: kUTTypeData as String, options: nil) { (item, error) in
+                             let url: URL! = item as? URL
+ 
+-                            results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: "text/plain"])
++                            results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: self.extractMimeType(from: url)])
+ 
+                             semaphore.signal()
+                         }
+@@ -157,11 +166,11 @@ public class ShareMenuReactView: NSObject {
+                             semaphore.signal()
+                         }
+                         semaphore.wait()
+-                    } else if provider.hasItemConformingToTypeIdentifier(kUTTypeData as String) {
+-                        provider.loadItem(forTypeIdentifier: kUTTypeData as String, options: nil) { (item, error) in
++                    } else if provider.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
++                        provider.loadItem(forTypeIdentifier: kUTTypeURL as String, options: nil) { (item, error) in
+                             let url: URL! = item as? URL
+ 
+-                            results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: self.extractMimeType(from: url)])
++                            results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: "text/plain"])
+ 
+                             semaphore.signal()
+                         }
 diff --git a/node_modules/react-native-share-menu/ios/ReactShareViewController.swift b/node_modules/react-native-share-menu/ios/ReactShareViewController.swift
 index f42bce6..d31fac9 100644
 --- a/node_modules/react-native-share-menu/ios/ReactShareViewController.swift
@@ -148,7 +184,7 @@ index f42bce6..d31fac9 100644
  
      ShareMenuReactView.attachViewDelegate(self)
 diff --git a/node_modules/react-native-share-menu/ios/ShareViewController.swift b/node_modules/react-native-share-menu/ios/ShareViewController.swift
-index 12d8c92..da029d3 100644
+index 12d8c92..130f7fb 100644
 --- a/node_modules/react-native-share-menu/ios/ShareViewController.swift
 +++ b/node_modules/react-native-share-menu/ios/ShareViewController.swift
 @@ -13,6 +13,7 @@ import MobileCoreServices
@@ -170,7 +206,41 @@ index 12d8c92..da029d3 100644
      if let hostAppId = Bundle.main.object(forInfoDictionaryKey: HOST_APP_IDENTIFIER_INFO_PLIST_KEY) as? String {
        self.hostAppId = hostAppId
      } else {
-@@ -222,7 +227,7 @@ class ShareViewController: SLComposeServiceViewController {
+@@ -73,7 +78,7 @@ class ShareViewController: SLComposeServiceViewController {
+       }
+ 
+       let semaphore = DispatchSemaphore(value: 0)
+-      var results: [Any] = []
++//      var results: [Any] = []
+ 
+       for item in items {
+         guard let attachments = item.attachments else {
+@@ -81,13 +86,21 @@ class ShareViewController: SLComposeServiceViewController {
+           return
+         }
+         
++
+         for provider in attachments {
+-          if provider.isText {
+-            self.storeText(withProvider: provider, semaphore)
++          
++          var info = provider.registeredTypeIdentifiers
++          var isImage = provider.hasItemConformingToTypeIdentifier("public.image")
++          var isFileUrl = provider.hasItemConformingToTypeIdentifier("public.file-url")
++          var isUrl = provider.hasItemConformingToTypeIdentifier("public.url")
++          var isText = provider.hasItemConformingToTypeIdentifier("public.text")
++          
++          if provider.isFileURL {
++            self.storeFile(withProvider: provider, semaphore)
+           } else if provider.isURL {
+             self.storeUrl(withProvider: provider, semaphore)
+           } else {
+-            self.storeFile(withProvider: provider, semaphore)
++            self.storeText(withProvider: provider, semaphore)
+           }
+ 
+           semaphore.wait()
+@@ -222,7 +235,7 @@ class ShareViewController: SLComposeServiceViewController {
        return
      }
      

--- a/patches/react-native-share-menu+6.0.0.patch
+++ b/patches/react-native-share-menu+6.0.0.patch
@@ -88,7 +88,7 @@ index e8e1b73..bdd4d79 100644
  
  export default {
 diff --git a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
-index e290cce..1df000a 100644
+index e290cce..e01453c 100644
 --- a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
 +++ b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
 @@ -18,8 +18,6 @@ public class ShareMenuReactView: NSObject {
@@ -112,39 +112,12 @@ index e290cce..1df000a 100644
      @objc(dismissExtension:)
      func dismissExtension(_ error: String?) {
          guard let extensionContext = ShareMenuReactView.viewDelegate?.loadExtensionContext() else {
-@@ -106,11 +109,17 @@ public class ShareMenuReactView: NSObject {
-                 }
- 
-                 for provider in attachments {
--                    if provider.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
--                        provider.loadItem(forTypeIdentifier: kUTTypeURL as String, options: nil) { (item, error) in
-+                    var info = provider.registeredTypeIdentifiers
-+                    var isImage = provider.hasItemConformingToTypeIdentifier("public.image")
-+                    var isFileUrl = provider.hasItemConformingToTypeIdentifier("public.file-url")
-+                    var isUrl = provider.hasItemConformingToTypeIdentifier("public.url")
-+                    var isText = provider.hasItemConformingToTypeIdentifier("public.text")
-+                    
-+                    if provider.hasItemConformingToTypeIdentifier(kUTTypeData as String) {
-+                        provider.loadItem(forTypeIdentifier: kUTTypeData as String, options: nil) { (item, error) in
+@@ -110,7 +113,7 @@ public class ShareMenuReactView: NSObject {
+                         provider.loadItem(forTypeIdentifier: kUTTypeURL as String, options: nil) { (item, error) in
                              let url: URL! = item as? URL
  
 -                            results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: "text/plain"])
 +                            results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: self.extractMimeType(from: url)])
- 
-                             semaphore.signal()
-                         }
-@@ -157,11 +166,11 @@ public class ShareMenuReactView: NSObject {
-                             semaphore.signal()
-                         }
-                         semaphore.wait()
--                    } else if provider.hasItemConformingToTypeIdentifier(kUTTypeData as String) {
--                        provider.loadItem(forTypeIdentifier: kUTTypeData as String, options: nil) { (item, error) in
-+                    } else if provider.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
-+                        provider.loadItem(forTypeIdentifier: kUTTypeURL as String, options: nil) { (item, error) in
-                             let url: URL! = item as? URL
- 
--                            results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: self.extractMimeType(from: url)])
-+                            results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: "text/plain"])
  
                              semaphore.signal()
                          }
@@ -184,7 +157,7 @@ index f42bce6..d31fac9 100644
  
      ShareMenuReactView.attachViewDelegate(self)
 diff --git a/node_modules/react-native-share-menu/ios/ShareViewController.swift b/node_modules/react-native-share-menu/ios/ShareViewController.swift
-index 12d8c92..130f7fb 100644
+index 12d8c92..da029d3 100644
 --- a/node_modules/react-native-share-menu/ios/ShareViewController.swift
 +++ b/node_modules/react-native-share-menu/ios/ShareViewController.swift
 @@ -13,6 +13,7 @@ import MobileCoreServices
@@ -206,41 +179,7 @@ index 12d8c92..130f7fb 100644
      if let hostAppId = Bundle.main.object(forInfoDictionaryKey: HOST_APP_IDENTIFIER_INFO_PLIST_KEY) as? String {
        self.hostAppId = hostAppId
      } else {
-@@ -73,7 +78,7 @@ class ShareViewController: SLComposeServiceViewController {
-       }
- 
-       let semaphore = DispatchSemaphore(value: 0)
--      var results: [Any] = []
-+//      var results: [Any] = []
- 
-       for item in items {
-         guard let attachments = item.attachments else {
-@@ -81,13 +86,21 @@ class ShareViewController: SLComposeServiceViewController {
-           return
-         }
-         
-+
-         for provider in attachments {
--          if provider.isText {
--            self.storeText(withProvider: provider, semaphore)
-+          
-+          var info = provider.registeredTypeIdentifiers
-+          var isImage = provider.hasItemConformingToTypeIdentifier("public.image")
-+          var isFileUrl = provider.hasItemConformingToTypeIdentifier("public.file-url")
-+          var isUrl = provider.hasItemConformingToTypeIdentifier("public.url")
-+          var isText = provider.hasItemConformingToTypeIdentifier("public.text")
-+          
-+          if provider.isFileURL {
-+            self.storeFile(withProvider: provider, semaphore)
-           } else if provider.isURL {
-             self.storeUrl(withProvider: provider, semaphore)
-           } else {
--            self.storeFile(withProvider: provider, semaphore)
-+            self.storeText(withProvider: provider, semaphore)
-           }
- 
-           semaphore.wait()
-@@ -222,7 +235,7 @@ class ShareViewController: SLComposeServiceViewController {
+@@ -222,7 +227,7 @@ class ShareViewController: SLComposeServiceViewController {
        return
      }
      

--- a/patches/react-native-share-menu+6.0.0.patch
+++ b/patches/react-native-share-menu+6.0.0.patch
@@ -88,10 +88,18 @@ index e8e1b73..bdd4d79 100644
  
  export default {
 diff --git a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
-index e290cce..e01453c 100644
+index e290cce..df9490b 100644
 --- a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
 +++ b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
-@@ -18,8 +18,6 @@ public class ShareMenuReactView: NSObject {
+@@ -7,6 +7,7 @@
+ 
+ import Foundation
+ import MobileCoreServices
++import UniformTypeIdentifiers
+ 
+ @objc(ShareMenuReactView)
+ public class ShareMenuReactView: NSObject {
+@@ -18,8 +19,6 @@ public class ShareMenuReactView: NSObject {
      }
  
      public static func attachViewDelegate(_ delegate: ReactShareViewDelegate!) {
@@ -100,7 +108,7 @@ index e290cce..e01453c 100644
          ShareMenuReactView.viewDelegate = delegate
      }
  
-@@ -27,6 +25,11 @@ public class ShareMenuReactView: NSObject {
+@@ -27,6 +26,11 @@ public class ShareMenuReactView: NSObject {
          ShareMenuReactView.viewDelegate = nil
      }
  
@@ -112,15 +120,74 @@ index e290cce..e01453c 100644
      @objc(dismissExtension:)
      func dismissExtension(_ error: String?) {
          guard let extensionContext = ShareMenuReactView.viewDelegate?.loadExtensionContext() else {
-@@ -110,7 +113,7 @@ public class ShareMenuReactView: NSObject {
+@@ -106,7 +110,22 @@ public class ShareMenuReactView: NSObject {
+                 }
+ 
+                 for provider in attachments {
+-                    if provider.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
++                    var info = provider.registeredTypeIdentifiers
++                    var isImage = provider.hasItemConformingToTypeIdentifier("public.image")
++                    var isFileUrl = provider.hasItemConformingToTypeIdentifier("public.file-url")
++                    var isUrl = provider.hasItemConformingToTypeIdentifier("public.url")
++                    var isText = provider.hasItemConformingToTypeIdentifier("public.text")
++                    
++                    if provider.hasItemConformingToTypeIdentifier(kUTTypeFileURL as String) {
++                        provider.loadItem(forTypeIdentifier: kUTTypeFileURL as String, options: nil) { (item, error) in
++                            let url: URL! = item as? URL
++                                
++                                results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: self.extractMimeType(from: url)])
++                            
++                            semaphore.signal()
++                        }
++                        semaphore.wait()
++                    } else if provider.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
                          provider.loadItem(forTypeIdentifier: kUTTypeURL as String, options: nil) { (item, error) in
                              let url: URL! = item as? URL
+                             
+@@ -115,16 +134,25 @@ public class ShareMenuReactView: NSObject {
+                             semaphore.signal()
+                         }
+                         semaphore.wait()
++                    } else if provider.hasItemConformingToTypeIdentifier(kUTTypeData as String) {
++                        provider.loadItem(forTypeIdentifier: kUTTypeData as String, options: nil) { (item, error) in
++                            let url: URL! = item as? URL
++                                
++                                results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: self.extractMimeType(from: url)])
++                            
++                            semaphore.signal()
++                        }
++                        semaphore.wait()
+                     } else if provider.hasItemConformingToTypeIdentifier(kUTTypeText as String) {
+                         provider.loadItem(forTypeIdentifier: kUTTypeText as String, options: nil) { (item, error) in
+-                            let text:String! = item as? String
++                            let text: String! = item as? String
  
--                            results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: "text/plain"])
-+                            results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: self.extractMimeType(from: url)])
+                             results.append([DATA_KEY: text, MIME_TYPE_KEY: "text/plain"])
  
                              semaphore.signal()
                          }
+                         semaphore.wait()
+-                    } else if provider.hasItemConformingToTypeIdentifier(kUTTypeImage as String) {
++                    }  else if provider.hasItemConformingToTypeIdentifier(kUTTypeImage as String) {
+                         provider.loadItem(forTypeIdentifier: kUTTypeImage as String, options: nil) { (item, error) in
+                             let imageUrl: URL! = item as? URL
+ 
+@@ -157,15 +185,6 @@ public class ShareMenuReactView: NSObject {
+                             semaphore.signal()
+                         }
+                         semaphore.wait()
+-                    } else if provider.hasItemConformingToTypeIdentifier(kUTTypeData as String) {
+-                        provider.loadItem(forTypeIdentifier: kUTTypeData as String, options: nil) { (item, error) in
+-                            let url: URL! = item as? URL
+-
+-                            results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: self.extractMimeType(from: url)])
+-
+-                            semaphore.signal()
+-                        }
+-                        semaphore.wait()
+                     } else {
+                         callback(nil, NSException(name: NSExceptionName(rawValue: "Error"), reason:"couldn't find provider", userInfo:nil))
+                     }
 diff --git a/node_modules/react-native-share-menu/ios/ReactShareViewController.swift b/node_modules/react-native-share-menu/ios/ReactShareViewController.swift
 index f42bce6..d31fac9 100644
 --- a/node_modules/react-native-share-menu/ios/ReactShareViewController.swift
@@ -157,7 +224,7 @@ index f42bce6..d31fac9 100644
  
      ShareMenuReactView.attachViewDelegate(self)
 diff --git a/node_modules/react-native-share-menu/ios/ShareViewController.swift b/node_modules/react-native-share-menu/ios/ShareViewController.swift
-index 12d8c92..da029d3 100644
+index 12d8c92..b6015f1 100644
 --- a/node_modules/react-native-share-menu/ios/ShareViewController.swift
 +++ b/node_modules/react-native-share-menu/ios/ShareViewController.swift
 @@ -13,6 +13,7 @@ import MobileCoreServices
@@ -179,7 +246,25 @@ index 12d8c92..da029d3 100644
      if let hostAppId = Bundle.main.object(forInfoDictionaryKey: HOST_APP_IDENTIFIER_INFO_PLIST_KEY) as? String {
        self.hostAppId = hostAppId
      } else {
-@@ -222,7 +227,7 @@ class ShareViewController: SLComposeServiceViewController {
+@@ -73,7 +78,6 @@ class ShareViewController: SLComposeServiceViewController {
+       }
+ 
+       let semaphore = DispatchSemaphore(value: 0)
+-      var results: [Any] = []
+ 
+       for item in items {
+         guard let attachments = item.attachments else {
+@@ -81,7 +85,9 @@ class ShareViewController: SLComposeServiceViewController {
+           return
+         }
+         
++
+         for provider in attachments {
++          
+           if provider.isText {
+             self.storeText(withProvider: provider, semaphore)
+           } else if provider.isURL {
+@@ -222,7 +228,7 @@ class ShareViewController: SLComposeServiceViewController {
        return
      }
      

--- a/patches/react-native-share-menu+6.0.0.patch
+++ b/patches/react-native-share-menu+6.0.0.patch
@@ -208,7 +208,7 @@ index f42bce6..d31fac9 100644
  
      ShareMenuReactView.attachViewDelegate(self)
 diff --git a/node_modules/react-native-share-menu/ios/ShareViewController.swift b/node_modules/react-native-share-menu/ios/ShareViewController.swift
-index 12d8c92..e4f689c 100644
+index 12d8c92..da029d3 100644
 --- a/node_modules/react-native-share-menu/ios/ShareViewController.swift
 +++ b/node_modules/react-native-share-menu/ios/ShareViewController.swift
 @@ -13,6 +13,7 @@ import MobileCoreServices
@@ -230,17 +230,7 @@ index 12d8c92..e4f689c 100644
      if let hostAppId = Bundle.main.object(forInfoDictionaryKey: HOST_APP_IDENTIFIER_INFO_PLIST_KEY) as? String {
        self.hostAppId = hostAppId
      } else {
-@@ -81,7 +86,9 @@ class ShareViewController: SLComposeServiceViewController {
-           return
-         }
- 
-+
-         for provider in attachments {
-+          
-           if provider.isText {
-             self.storeText(withProvider: provider, semaphore)
-           } else if provider.isURL {
-@@ -222,7 +229,7 @@ class ShareViewController: SLComposeServiceViewController {
+@@ -222,7 +227,7 @@ class ShareViewController: SLComposeServiceViewController {
        return
      }
      

--- a/patches/react-native-share-menu+6.0.0.patch
+++ b/patches/react-native-share-menu+6.0.0.patch
@@ -208,7 +208,7 @@ index f42bce6..d31fac9 100644
  
      ShareMenuReactView.attachViewDelegate(self)
 diff --git a/node_modules/react-native-share-menu/ios/ShareViewController.swift b/node_modules/react-native-share-menu/ios/ShareViewController.swift
-index 12d8c92..91646f9 100644
+index 12d8c92..e4f689c 100644
 --- a/node_modules/react-native-share-menu/ios/ShareViewController.swift
 +++ b/node_modules/react-native-share-menu/ios/ShareViewController.swift
 @@ -13,6 +13,7 @@ import MobileCoreServices
@@ -230,15 +230,7 @@ index 12d8c92..91646f9 100644
      if let hostAppId = Bundle.main.object(forInfoDictionaryKey: HOST_APP_IDENTIFIER_INFO_PLIST_KEY) as? String {
        self.hostAppId = hostAppId
      } else {
-@@ -73,7 +78,6 @@ class ShareViewController: SLComposeServiceViewController {
-       }
- 
-       let semaphore = DispatchSemaphore(value: 0)
--      var results: [Any] = []
- 
-       for item in items {
-         guard let attachments = item.attachments else {
-@@ -81,7 +85,9 @@ class ShareViewController: SLComposeServiceViewController {
+@@ -81,7 +86,9 @@ class ShareViewController: SLComposeServiceViewController {
            return
          }
  
@@ -248,7 +240,7 @@ index 12d8c92..91646f9 100644
            if provider.isText {
              self.storeText(withProvider: provider, semaphore)
            } else if provider.isURL {
-@@ -222,7 +228,7 @@ class ShareViewController: SLComposeServiceViewController {
+@@ -222,7 +229,7 @@ class ShareViewController: SLComposeServiceViewController {
        return
      }
      

--- a/patches/react-native-share-menu+6.0.0.patch
+++ b/patches/react-native-share-menu+6.0.0.patch
@@ -88,7 +88,7 @@ index e8e1b73..bdd4d79 100644
  
  export default {
 diff --git a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
-index e290cce..df9490b 100644
+index e290cce..f03b514 100644
 --- a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
 +++ b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
 @@ -7,6 +7,7 @@
@@ -120,17 +120,11 @@ index e290cce..df9490b 100644
      @objc(dismissExtension:)
      func dismissExtension(_ error: String?) {
          guard let extensionContext = ShareMenuReactView.viewDelegate?.loadExtensionContext() else {
-@@ -106,7 +110,22 @@ public class ShareMenuReactView: NSObject {
+@@ -106,7 +110,16 @@ public class ShareMenuReactView: NSObject {
                  }
  
                  for provider in attachments {
 -                    if provider.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
-+                    var info = provider.registeredTypeIdentifiers
-+                    var isImage = provider.hasItemConformingToTypeIdentifier("public.image")
-+                    var isFileUrl = provider.hasItemConformingToTypeIdentifier("public.file-url")
-+                    var isUrl = provider.hasItemConformingToTypeIdentifier("public.url")
-+                    var isText = provider.hasItemConformingToTypeIdentifier("public.text")
-+                    
 +                    if provider.hasItemConformingToTypeIdentifier(kUTTypeFileURL as String) {
 +                        provider.loadItem(forTypeIdentifier: kUTTypeFileURL as String, options: nil) { (item, error) in
 +                            let url: URL! = item as? URL
@@ -143,20 +137,9 @@ index e290cce..df9490b 100644
 +                    } else if provider.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
                          provider.loadItem(forTypeIdentifier: kUTTypeURL as String, options: nil) { (item, error) in
                              let url: URL! = item as? URL
-                             
-@@ -115,16 +134,25 @@ public class ShareMenuReactView: NSObject {
-                             semaphore.signal()
-                         }
+ 
+@@ -117,14 +130,23 @@ public class ShareMenuReactView: NSObject {
                          semaphore.wait()
-+                    } else if provider.hasItemConformingToTypeIdentifier(kUTTypeData as String) {
-+                        provider.loadItem(forTypeIdentifier: kUTTypeData as String, options: nil) { (item, error) in
-+                            let url: URL! = item as? URL
-+                                
-+                                results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: self.extractMimeType(from: url)])
-+                            
-+                            semaphore.signal()
-+                        }
-+                        semaphore.wait()
                      } else if provider.hasItemConformingToTypeIdentifier(kUTTypeText as String) {
                          provider.loadItem(forTypeIdentifier: kUTTypeText as String, options: nil) { (item, error) in
 -                            let text:String! = item as? String
@@ -168,11 +151,20 @@ index e290cce..df9490b 100644
                          }
                          semaphore.wait()
 -                    } else if provider.hasItemConformingToTypeIdentifier(kUTTypeImage as String) {
++                    } else if provider.hasItemConformingToTypeIdentifier(kUTTypeData as String) {
++                        provider.loadItem(forTypeIdentifier: kUTTypeData as String, options: nil) { (item, error) in
++                            let url: URL! = item as? URL
++                                
++                                results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: self.extractMimeType(from: url)])
++                            
++                            semaphore.signal()
++                        }
++                        semaphore.wait()
 +                    }  else if provider.hasItemConformingToTypeIdentifier(kUTTypeImage as String) {
                          provider.loadItem(forTypeIdentifier: kUTTypeImage as String, options: nil) { (item, error) in
                              let imageUrl: URL! = item as? URL
  
-@@ -157,15 +185,6 @@ public class ShareMenuReactView: NSObject {
+@@ -157,15 +179,6 @@ public class ShareMenuReactView: NSObject {
                              semaphore.signal()
                          }
                          semaphore.wait()
@@ -224,7 +216,7 @@ index f42bce6..d31fac9 100644
  
      ShareMenuReactView.attachViewDelegate(self)
 diff --git a/node_modules/react-native-share-menu/ios/ShareViewController.swift b/node_modules/react-native-share-menu/ios/ShareViewController.swift
-index 12d8c92..b6015f1 100644
+index 12d8c92..91646f9 100644
 --- a/node_modules/react-native-share-menu/ios/ShareViewController.swift
 +++ b/node_modules/react-native-share-menu/ios/ShareViewController.swift
 @@ -13,6 +13,7 @@ import MobileCoreServices
@@ -257,7 +249,7 @@ index 12d8c92..b6015f1 100644
 @@ -81,7 +85,9 @@ class ShareViewController: SLComposeServiceViewController {
            return
          }
-         
+ 
 +
          for provider in attachments {
 +          

--- a/patches/react-native-share-menu+6.0.0.patch
+++ b/patches/react-native-share-menu+6.0.0.patch
@@ -88,18 +88,10 @@ index e8e1b73..bdd4d79 100644
  
  export default {
 diff --git a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
-index e290cce..f03b514 100644
+index e290cce..a3a10de 100644
 --- a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
 +++ b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
-@@ -7,6 +7,7 @@
- 
- import Foundation
- import MobileCoreServices
-+import UniformTypeIdentifiers
- 
- @objc(ShareMenuReactView)
- public class ShareMenuReactView: NSObject {
-@@ -18,8 +19,6 @@ public class ShareMenuReactView: NSObject {
+@@ -18,8 +18,6 @@ public class ShareMenuReactView: NSObject {
      }
  
      public static func attachViewDelegate(_ delegate: ReactShareViewDelegate!) {
@@ -108,7 +100,7 @@ index e290cce..f03b514 100644
          ShareMenuReactView.viewDelegate = delegate
      }
  
-@@ -27,6 +26,11 @@ public class ShareMenuReactView: NSObject {
+@@ -27,6 +25,11 @@ public class ShareMenuReactView: NSObject {
          ShareMenuReactView.viewDelegate = nil
      }
  
@@ -120,7 +112,7 @@ index e290cce..f03b514 100644
      @objc(dismissExtension:)
      func dismissExtension(_ error: String?) {
          guard let extensionContext = ShareMenuReactView.viewDelegate?.loadExtensionContext() else {
-@@ -106,7 +110,16 @@ public class ShareMenuReactView: NSObject {
+@@ -106,7 +109,16 @@ public class ShareMenuReactView: NSObject {
                  }
  
                  for provider in attachments {
@@ -138,7 +130,7 @@ index e290cce..f03b514 100644
                          provider.loadItem(forTypeIdentifier: kUTTypeURL as String, options: nil) { (item, error) in
                              let url: URL! = item as? URL
  
-@@ -117,14 +130,23 @@ public class ShareMenuReactView: NSObject {
+@@ -117,14 +129,23 @@ public class ShareMenuReactView: NSObject {
                          semaphore.wait()
                      } else if provider.hasItemConformingToTypeIdentifier(kUTTypeText as String) {
                          provider.loadItem(forTypeIdentifier: kUTTypeText as String, options: nil) { (item, error) in
@@ -164,7 +156,7 @@ index e290cce..f03b514 100644
                          provider.loadItem(forTypeIdentifier: kUTTypeImage as String, options: nil) { (item, error) in
                              let imageUrl: URL! = item as? URL
  
-@@ -157,15 +179,6 @@ public class ShareMenuReactView: NSObject {
+@@ -157,15 +178,6 @@ public class ShareMenuReactView: NSObject {
                              semaphore.signal()
                          }
                          semaphore.wait()

--- a/src/libs/Share/index.ios.js
+++ b/src/libs/Share/index.ios.js
@@ -2,6 +2,7 @@ import {moveFile, pathForGroup} from 'react-native-fs';
 import {ShareMenuReactView} from 'react-native-share-menu';
 import CONST from '../../CONST';
 import Navigation from '../Navigation/Navigation';
+import * as NetworkStore from '../Network/NetworkStore';
 import * as ShareActions from '../actions/Share';
 import hasNoShareData from './hasNoShareData';
 import navigateToShare from './navigateToShare';
@@ -14,9 +15,7 @@ const registerListener = () => {
         ShareMenuReactView.data().then((shared) => {
             if (hasNoShareData(shared)) return;
             const share = normalizeShareData(shared);
-            if (share.mimeType === 'text/plain') {
-                navigateToShare(share);
-            } else {
+            if (NetworkStore.isOffline() && share.mimeType !== 'text/plain') {
                 // move to app group shared directory for offline uploads
                 pathForGroup(CONST.IOS_APP_GROUP).then((sharedDir) => {
                     const filename = share.data.split('/').pop();
@@ -25,6 +24,8 @@ const registerListener = () => {
                         navigateToShare({...share, data: destPath});
                     });
                 });
+            } else {
+                navigateToShare(share);
             }
         });
     });


### PR DESCRIPTION
Updates RNSM patch to handle URLS from files.

Anecdotal Data type checks:

File Type | View Rendered
M4V: :white_check_mark:  | Download Link :white_check_mark:
GIF: :white_check_mark: | Image View :white_check_mark:
OGV: :white_check_mark:  | Download Link :white_check_mark:
MOV: :white_check_mark: | Download Link :white_check_mark:
XLS: :white_check_mark:  | Download Link :white_check_mark:
PDF: :white_check_mark:  | PDF View :x:
DOCX: :white_check_mark:  | Download Link :white_check_mark:
CSV: :white_check_mark:  | Download Link :white_check_mark:

I believe there's something wrong with the PDFAttachmentView that's been updated in a more recent version of main. I'll create a card to track this issue.