### PR TITLE
Dismiss keyboard on "done" submit on message page

### DIFF
--- a/src/pages/ShareMessagePage.js
+++ b/src/pages/ShareMessagePage.js
@@ -49,6 +49,8 @@ function ShareMessagePage(props) {
                             submitOnEnter={false}
                             onChangeText={setMessage}
                             value={message}
+                            returnKeyType="done"
+                            blurOnSubmit
                         />
                     </View>
                     {!isTextShare && (


### PR DESCRIPTION
This fixes the weird UX experience of not being able to dismiss the keyboard on the message page of the share extension.

The UX drawback is that users will not be able to "return" to a new line to add spaces between sentences, though I don't believe that's an expected behavior.

https://github.com/Expensify/App/assets/8878532/17f951bf-f96b-42f2-aea6-bd4970ec7359

