### PR TITLE
Update Handing of kUTType's and Mimetypes within RNSM

### DIFF
--- a/ios/NewExpensifyShare/Info.plist
+++ b/ios/NewExpensifyShare/Info.plist
@@ -25,6 +25,8 @@
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<dict>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<string>1</string>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
 				<integer>1</integer>
 				<key>NSExtensionActivationSupportsText</key>

--- a/patches/react-native-share-menu+6.0.0.patch
+++ b/patches/react-native-share-menu+6.0.0.patch
@@ -88,7 +88,7 @@ index e8e1b73..bdd4d79 100644
  
  export default {
 diff --git a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
-index e290cce..775957d 100644
+index e290cce..c40036d 100644
 --- a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
 +++ b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
 @@ -18,8 +18,6 @@ public class ShareMenuReactView: NSObject {
@@ -112,6 +112,34 @@ index e290cce..775957d 100644
      @objc(dismissExtension:)
      func dismissExtension(_ error: String?) {
          guard let extensionContext = ShareMenuReactView.viewDelegate?.loadExtensionContext() else {
+@@ -106,7 +109,17 @@ public class ShareMenuReactView: NSObject {
+                 }
+ 
+                 for provider in attachments {
+-                    if provider.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
++                    
++                    if provider.hasItemConformingToTypeIdentifier(kUTTypeFileURL as String) {
++                        provider.loadItem(forTypeIdentifier: kUTTypeFileURL as String, options: nil) { (item, error) in
++                            let url: URL! = item as? URL
++                            
++                            results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: self.extractMimeType(from: url)])
++                            
++                            semaphore.signal()
++                        }
++                        semaphore.wait()
++                    } else if provider.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
+                         provider.loadItem(forTypeIdentifier: kUTTypeURL as String, options: nil) { (item, error) in
+                             let url: URL! = item as? URL
+ 
+@@ -117,7 +130,7 @@ public class ShareMenuReactView: NSObject {
+                         semaphore.wait()
+                     } else if provider.hasItemConformingToTypeIdentifier(kUTTypeText as String) {
+                         provider.loadItem(forTypeIdentifier: kUTTypeText as String, options: nil) { (item, error) in
+-                            let text:String! = item as? String
++                            let text: String! = item as? String
+ 
+                             results.append([DATA_KEY: text, MIME_TYPE_KEY: "text/plain"])
+ 
 diff --git a/node_modules/react-native-share-menu/ios/ReactShareViewController.swift b/node_modules/react-native-share-menu/ios/ReactShareViewController.swift
 index f42bce6..ad4bab9 100644
 --- a/node_modules/react-native-share-menu/ios/ReactShareViewController.swift

--- a/src/libs/Share/index.ios.js
+++ b/src/libs/Share/index.ios.js
@@ -2,6 +2,7 @@ import {exists, moveFile, pathForGroup, unlink} from 'react-native-fs';
 import {ShareMenuReactView} from 'react-native-share-menu';
 import CONST from '../../CONST';
 import Navigation from '../Navigation/Navigation';
+import * as NetworkStore from '../Network/NetworkStore';
 import * as ShareActions from '../actions/Share';
 import hasNoShareData from './hasNoShareData';
 import navigateToShare from './navigateToShare';
@@ -14,9 +15,7 @@ const registerListener = () => {
         ShareMenuReactView.data().then((shared) => {
             if (hasNoShareData(shared)) return;
             const share = normalizeShareData(shared);
-            if (share.mimeType === 'text/plain') {
-                navigateToShare(share);
-            } else {
+            if (NetworkStore.isOffline() && share.mimeType !== 'text/plain') {
                 // move to app group shared directory for offline uploads
                 pathForGroup(CONST.IOS_APP_GROUP).then((sharedDir) => {
                     const filename = share.data.split('/').pop();
@@ -35,6 +34,8 @@ const registerListener = () => {
                         });
                     });
                 });
+            } else {
+                navigateToShare(share);
             }
         });
     });


### PR DESCRIPTION
Updates RNSM patch to handle URLS from files.

Anecdotal Data type checks:

File Type | View Rendered
M4V: ✅ | Download Link ✅
GIF: ✅ | Image View ✅
OGV: ✅ | Download Link ✅
MOV: ✅ | Download Link ✅
XLS: ✅ | Download Link ✅
PDF: ✅ | PDF View ✅
DOCX: ✅ | Download Link ✅
CSV: ✅ | Download Link ✅