### PR TITLE
Display file title in Share Message View

### DIFF
--- a/src/pages/ShareMessagePage.js
+++ b/src/pages/ShareMessagePage.js
@@ -57,7 +57,10 @@ function ShareMessagePage(props) {
                             <Text style={styles.textLabelSupporting}>{props.translate('common.attachment')}</Text>
                             {!!share.source && (
                                 <View style={{borderRadius: 8, height: 200, marginTop: 8, overflow: 'hidden', width: '100%'}}>
-                                    <AttachmentView source={share.source} />
+                                    <AttachmentView
+                                        source={share.source}
+                                        file={share}
+                                    />
                                 </View>
                             )}
                         </View>


### PR DESCRIPTION

https://github.com/infinitered/ExpensifyApp/assets/8878532/9e08a2b4-7e42-4520-9ab5-b3017cd6c08b

This displays the title of the file in the AttachmentView.

I had considered reworking the `AttachmentView` so that we just provide the file and the source is grabbed off of it, but they're using it for other use cases when the source is for an icon or something.