### PR TITLE
Implement Base Android Sharing

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,11 +30,20 @@
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:theme="@style/BootTheme"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:documentLaunchMode="never">
 
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+
+            <!-- Receive single-item shares, of any mimeType, from other apps -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
             </intent-filter>
 
             <!-- Custom URI handlers. Used to intercept Urban Airship deep links. -->

--- a/patches/react-native-share-menu+6.0.0.patch
+++ b/patches/react-native-share-menu+6.0.0.patch
@@ -29,6 +29,27 @@ index 9557fdb..26825b5 100644
          versionCode 1
          versionName "1.0"
          ndk {
+diff --git a/node_modules/react-native-share-menu/android/src/main/java/com/meedan/ShareMenuModule.java b/node_modules/react-native-share-menu/android/src/main/java/com/meedan/ShareMenuModule.java
+index 09abd7b..058dd1c 100644
+--- a/node_modules/react-native-share-menu/android/src/main/java/com/meedan/ShareMenuModule.java
++++ b/node_modules/react-native-share-menu/android/src/main/java/com/meedan/ShareMenuModule.java
+@@ -112,6 +112,16 @@ public class ShareMenuModule extends ReactContextBaseJavaModule implements Activ
+     clearSharedText();
+   }
+ 
++  @ReactMethod
++  public void addListener(String eventName) {
++    // Required for RN built in Event Emitter Calls.
++  }
++
++  @ReactMethod
++  public void removeListeners(Integer count) {
++    // Required for RN built in Event Emitter Calls.
++  }
++
+   private void dispatchEvent(ReadableMap shared) {
+     if (mReactContext == null || !mReactContext.hasActiveCatalystInstance()) {
+       return;
 diff --git a/node_modules/react-native-share-menu/ios/Constants.swift b/node_modules/react-native-share-menu/ios/Constants.swift
 index 08385b7..e22bdfa 100644
 --- a/node_modules/react-native-share-menu/ios/Constants.swift

--- a/patches/react-native-share-menu+6.0.0.patch
+++ b/patches/react-native-share-menu+6.0.0.patch
@@ -1,3 +1,34 @@
+diff --git a/node_modules/react-native-share-menu/android/build.gradle b/node_modules/react-native-share-menu/android/build.gradle
+index 9557fdb..26825b5 100644
+--- a/node_modules/react-native-share-menu/android/build.gradle
++++ b/node_modules/react-native-share-menu/android/build.gradle
+@@ -1,12 +1,22 @@
+ apply plugin: 'com.android.library'
+ 
++buildscript {
++    ext {
++        rnsmDefaultTargetSdkVersion = 31
++        rnsmDefaultCompileSdkVersion = 31
++        rnsmDefaultMinSdkVersion = 21
++    }
++    ext.safeExtGet = {prop, fallback ->
++        rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
++    }
++}
++
+ android {
+-    compileSdkVersion 29
+-    buildToolsVersion "29.0.2"
++    compileSdkVersion safeExtGet('compileSdkVersion', rnsmDefaultCompileSdkVersion)
+ 
+     defaultConfig {
+-        minSdkVersion 16
+-        targetSdkVersion 29
++        minSdkVersion safeExtGet('minSdkVersion', rnsmDefaultCompileSdkVersion)
++        targetSdkVersion safeExtGet('targetSdkVersion', rnsmDefaultCompileSdkVersion)
+         versionCode 1
+         versionName "1.0"
+         ndk {
 diff --git a/node_modules/react-native-share-menu/ios/Constants.swift b/node_modules/react-native-share-menu/ios/Constants.swift
 index 08385b7..e22bdfa 100644
 --- a/node_modules/react-native-share-menu/ios/Constants.swift

--- a/src/hooks/useReactNativeShareMenuData.js
+++ b/src/hooks/useReactNativeShareMenuData.js
@@ -20,7 +20,7 @@ export default function useReactNativeShareMenuData() {
     const handleShare = useCallback((item) => {
         console.log("RECEIVED:")
         console.log(item);
-        if (!item || isEmpty(item) || !item[0].data || isEmpty(item[0].data)) {
+        if (!item || isEmpty(item) || isEmpty(item[0]) || !item[0].data || isEmpty(item[0].data)) {
             console.log(item);
             console.warn("Received empty share data");
             return;


### PR DESCRIPTION
# Reimplent Basic Android Sharing 

This PR implements basic android sharing. It follows the `react-native-share-menu` android instructions and makes a few patches to android build scripts to make it work.

## Patch `react-native-share-menu`: `build.gradle` 

- Updates the build script to be compatible with current versions of react native -- using `safeExtGet('targetSdkVersion',rnsmDefaultCompileSdkVersion)` so that we won't need to manually patch for every update

## Patch `react-native-share-menu`:`ShareMenuModule.java`

- add some required methods as described


