### PR TITLE
Implement ViolationUtils lib #31083 

### DIFF
--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -261,6 +261,7 @@ const ONYXKEYS = {
         REPORT_USER_IS_LEAVING_ROOM: 'reportUserIsLeavingRoom_',
         SECURITY_GROUP: 'securityGroup_',
         TRANSACTION: 'transactions_',
+        TRANSACTION_VIOLATIONS: 'transactionViolations_',
         SPLIT_TRANSACTION_DRAFT: 'splitTransactionDraft_',
         PRIVATE_NOTES_DRAFT: 'privateNotesDraft_',
         NEXT_STEP: 'reportNextStep_',

--- a/src/libs/Violations/ViolationsUtils.ts
+++ b/src/libs/Violations/ViolationsUtils.ts
@@ -1,0 +1,88 @@
+// TODO: String literal for Violation Type
+import {PolicyTags, Transaction} from '@src/types/onyx';
+import {PolicyCategories} from '@src/types/onyx/PolicyCategory';
+
+type ViolationType =string;
+
+// TODO: String literal for Violation Name
+type ViolationName = string;
+
+type ViolationField = 'merchant' | 'amount' | 'category' | 'date' | 'tag' | 'comment' | 'billable' | 'receipt' | 'tax';
+
+type TransactionViolation = {
+    type: ViolationType;
+    name: ViolationName;
+    userMessage: string;
+    data?: Record<string, string>
+};
+
+const formFields = {
+    merchant: 'merchant',
+    amount: 'amount',
+    category: 'category',
+    date: 'date',
+    tag: 'tag',
+    comment: 'comment',
+    billable: 'billable',
+    receipt: 'receipt',
+    tax: 'tax',
+};
+
+const violationFields = {
+    perDayLimit: formFields.amount,
+    maxAge: formFields.date,
+    overLimit: formFields.amount,
+    overLimitAttendee: formFields.amount,
+    overCategoryLimit: formFields.amount,
+    receiptRequired: formFields.receipt,
+    missingCategory: formFields.category,
+    categoryOutOfPolicy: formFields.category,
+    missingTag: formFields.tag,
+    tagOutOfPolicy: formFields.tag,
+    missingComment: formFields.comment,
+    taxRequired: formFields.tax,
+    taxOutOfPolicy: formFields.tax,
+    billableExpense: formFields.billable,
+};
+
+
+
+const ViolationsUtils = {
+    getViolationForField(transactionViolation:TransactionViolation, field:ViolationField
+) :string {
+        console.log('getViolationsForField()', {transactionViolation, field});
+        throw new Error('Not implemented: getViolationsForField');
+    },
+    getViolationsOnyxData(
+        {
+            transaction,
+            transactionViolations,
+            policyRequiresCategories,
+            policyRequiresTags,
+            policyCategories,
+            policyTags
+        }:{
+            transaction: Transaction,
+            transactionViolations: TransactionViolation,
+            policyRequiresTags: boolean,
+            policyTags: PolicyTags,
+            policyRequiresCategories:boolean,
+            policyCategories: PolicyCategories
+        }){
+
+        console.log('getViolationsOnyxData()', {
+            transaction,
+            transactionViolations,
+            policyRequiresCategories,
+            policyRequiresTags,
+            policyCategories,
+            policyTags
+        });
+
+        throw new Error('Not implemented: getViolationsOnyxData()');
+    },
+
+
+}
+
+export default ViolationsUtils;

--- a/src/libs/Violations/ViolationsUtils.ts
+++ b/src/libs/Violations/ViolationsUtils.ts
@@ -1,25 +1,12 @@
-import ONYXKEYS from '@src/ONYXKEYS';
-import {
-    Transaction,
-    TransactionViolation,
-    PolicyTags,
-    PolicyCategories,
-} from '@src/types/onyx';
-import Onyx from 'react-native-onyx';
 import reject from 'lodash/reject';
+import Onyx from 'react-native-onyx';
+import ONYXKEYS from '@src/ONYXKEYS';
+import {PolicyCategories, PolicyTags, Transaction, TransactionViolation} from '@src/types/onyx';
 import possibleViolationsByField, {ViolationField} from './possibleViolationsByField';
 
-
-
 const ViolationsUtils = {
-    getViolationForField(
-        transactionViolations: TransactionViolation[],
-        field: ViolationField,
-        translate: (key:string)=>string
-    ): string[] {
-        return transactionViolations
-            .filter(violation => possibleViolationsByField[field]?.includes(violation.name))
-            .map(violation => translate(violation.name));
+    getViolationForField(transactionViolations: TransactionViolation[], field: ViolationField, translate: (key: string) => string): string[] {
+        return transactionViolations.filter((violation) => possibleViolationsByField[field]?.includes(violation.name)).map((violation) => translate(violation.name));
     },
 
     getViolationsOnyxData(
@@ -36,15 +23,14 @@ const ViolationsUtils = {
         /** Collection of policy categories and their enabled states. */
         policyCategories: PolicyCategories,
     ): {
-        onyxMethod: string,
-        key: string,
-        value: TransactionViolation[]
+        onyxMethod: string;
+        key: string;
+        value: TransactionViolation[];
     } {
         let newTransactionViolations = [...transactionViolations];
 
-
         if (policyRequiresCategories) {
-            const categoryViolationExists = transactionViolations.some(violation => violation.name === 'categoryOutOfPolicy');
+            const categoryViolationExists = transactionViolations.some((violation) => violation.name === 'categoryOutOfPolicy');
             const categoryIsInPolicy = policyCategories[transaction.category]?.enabled;
 
             // Add 'categoryOutOfPolicy' violation if category is not in policy
@@ -58,10 +44,9 @@ const ViolationsUtils = {
             }
         }
 
-
         if (policyRequiresTags) {
             // Add 'tagOutOfPolicy' violation if tag is not in policy
-            const tagViolationExists = transactionViolations.some(violation => violation.name === 'tagOutOfPolicy');
+            const tagViolationExists = transactionViolations.some((violation) => violation.name === 'tagOutOfPolicy');
             const tagInPolicy = policyTags[transaction.tag]?.enabled;
             if (!tagViolationExists && transaction.tag && !tagInPolicy) {
                 newTransactionViolations.push({name: 'tagOutOfPolicy', type: 'violation', userMessage: ''});
@@ -76,7 +61,7 @@ const ViolationsUtils = {
         return {
             onyxMethod: Onyx.METHOD.SET,
             key: `${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transaction.transactionID}`,
-            value: newTransactionViolations
+            value: newTransactionViolations,
         };
     },
 };

--- a/src/libs/Violations/index.ts
+++ b/src/libs/Violations/index.ts
@@ -1,0 +1,3 @@
+import * as ViolationsUtils from './ViolationsUtils';
+
+export default ViolationsUtils;

--- a/src/libs/Violations/possibleViolationsByField.ts
+++ b/src/libs/Violations/possibleViolationsByField.ts
@@ -1,0 +1,52 @@
+import {ViolationName} from '@src/types/onyx';
+import invertBy from 'lodash/invertBy';
+
+
+/**
+ * Map from Violation Names to the field where that violation can occur
+ */
+const violationFields: Record<ViolationName, ViolationField> = {
+    perDayLimit: 'amount',
+    maxAge: 'date',
+    overLimit: 'amount',
+    overLimitAttendee: 'amount',
+    overCategoryLimit: 'amount',
+    receiptRequired: 'receipt',
+    missingCategory: 'category',
+    categoryOutOfPolicy: 'category',
+    missingTag: 'tag',
+    tagOutOfPolicy: 'tag',
+    missingComment: 'comment',
+    taxRequired: 'tax',
+    taxOutOfPolicy: 'tax',
+    billableExpense: 'billable',
+};
+
+/**
+ * Names of Fields where violations can occur
+ */
+type ViolationField =
+    | 'merchant'
+    | 'amount'
+    | 'category'
+    | 'date'
+    | 'tag'
+    | 'comment'
+    | 'billable'
+    | 'receipt'
+    | 'tax';
+
+/**
+ * Map from field name to array of violation types that can occur on that field.
+ * @example
+ * {
+ *   // ...
+ *   category: ['missingCategory', 'categoryOutOfPolicy']
+ *   // ...
+ * }
+ */
+const possibleViolationsByField = invertBy(violationFields, (value) => value) as Record<ViolationField, ViolationName[]>;
+
+
+export default possibleViolationsByField
+export type {ViolationField}

--- a/src/libs/Violations/possibleViolationsByField.ts
+++ b/src/libs/Violations/possibleViolationsByField.ts
@@ -1,6 +1,5 @@
-import {ViolationName} from '@src/types/onyx';
 import invertBy from 'lodash/invertBy';
-
+import {ViolationName} from '@src/types/onyx';
 
 /**
  * Map from Violation Names to the field where that violation can occur
@@ -25,16 +24,7 @@ const violationFields: Record<ViolationName, ViolationField> = {
 /**
  * Names of Fields where violations can occur
  */
-type ViolationField =
-    | 'merchant'
-    | 'amount'
-    | 'category'
-    | 'date'
-    | 'tag'
-    | 'comment'
-    | 'billable'
-    | 'receipt'
-    | 'tax';
+type ViolationField = 'merchant' | 'amount' | 'category' | 'date' | 'tag' | 'comment' | 'billable' | 'receipt' | 'tax';
 
 /**
  * Map from field name to array of violation types that can occur on that field.
@@ -47,6 +37,5 @@ type ViolationField =
  */
 const possibleViolationsByField = invertBy(violationFields, (value) => value) as Record<ViolationField, ViolationName[]>;
 
-
-export default possibleViolationsByField
-export type {ViolationField}
+export default possibleViolationsByField;
+export type {ViolationField};

--- a/src/types/onyx/PolicyCategory.ts
+++ b/src/types/onyx/PolicyCategory.ts
@@ -19,4 +19,6 @@ type PolicyCategory = {
     origin: string;
 };
 
+type PolicyCategories = Record<string, PolicyCategory>;
 export default PolicyCategory;
+export type {PolicyCategories};

--- a/src/types/onyx/TransactionViolation.ts
+++ b/src/types/onyx/TransactionViolation.ts
@@ -7,21 +7,20 @@
  * Names of the various Transaction Violation types
  */
 type ViolationName =
-    | "perDayLimit"
-    | "maxAge"
-    | "overLimit"
-    | "overLimitAttendee"
-    | "overCategoryLimit"
-    | "receiptRequired"
-    | "missingCategory"
-    | "categoryOutOfPolicy"
-    | "missingTag"
-    | "tagOutOfPolicy"
-    | "missingComment"
-    | "taxRequired"
-    | "taxOutOfPolicy"
-    | "billableExpense";
-
+    | 'perDayLimit'
+    | 'maxAge'
+    | 'overLimit'
+    | 'overLimitAttendee'
+    | 'overCategoryLimit'
+    | 'receiptRequired'
+    | 'missingCategory'
+    | 'categoryOutOfPolicy'
+    | 'missingTag'
+    | 'tagOutOfPolicy'
+    | 'missingComment'
+    | 'taxRequired'
+    | 'taxOutOfPolicy'
+    | 'billableExpense';
 
 type ViolationType = string;
 
@@ -29,11 +28,7 @@ type TransactionViolation = {
     type: ViolationType;
     name: ViolationName;
     userMessage: string;
-    data?: Record<string, string>
+    data?: Record<string, string>;
 };
 
-export type {
-    TransactionViolation,
-    ViolationName,
-    ViolationType,
-};
+export type {TransactionViolation, ViolationName, ViolationType};

--- a/src/types/onyx/TransactionViolation.ts
+++ b/src/types/onyx/TransactionViolation.ts
@@ -1,0 +1,39 @@
+/**
+ * @module TransactionViolation
+ * @description Transaction Violation
+ */
+
+/**
+ * Names of the various Transaction Violation types
+ */
+type ViolationName =
+    | "perDayLimit"
+    | "maxAge"
+    | "overLimit"
+    | "overLimitAttendee"
+    | "overCategoryLimit"
+    | "receiptRequired"
+    | "missingCategory"
+    | "categoryOutOfPolicy"
+    | "missingTag"
+    | "tagOutOfPolicy"
+    | "missingComment"
+    | "taxRequired"
+    | "taxOutOfPolicy"
+    | "billableExpense";
+
+
+type ViolationType = string;
+
+type TransactionViolation = {
+    type: ViolationType;
+    name: ViolationName;
+    userMessage: string;
+    data?: Record<string, string>
+};
+
+export type {
+    TransactionViolation,
+    ViolationName,
+    ViolationType,
+};

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -21,7 +21,7 @@ import PersonalBankAccount from './PersonalBankAccount';
 import PersonalDetails from './PersonalDetails';
 import PlaidData from './PlaidData';
 import Policy from './Policy';
-import PolicyCategory from './PolicyCategory';
+import PolicyCategory, {PolicyCategories} from './PolicyCategory';
 import PolicyMember, {PolicyMembers} from './PolicyMember';
 import PolicyTag, {PolicyTags} from './PolicyTag';
 import PrivatePersonalDetails from './PrivatePersonalDetails';
@@ -78,6 +78,7 @@ export type {
     PlaidData,
     Policy,
     PolicyCategory,
+    PolicyCategories,
     PolicyMember,
     PolicyMembers,
     PolicyTag,

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -49,6 +49,11 @@ import WalletOnfido from './WalletOnfido';
 import WalletStatement from './WalletStatement';
 import WalletTerms from './WalletTerms';
 import WalletTransfer from './WalletTransfer';
+import {
+    TransactionViolation,
+    ViolationName,
+    ViolationType,
+} from './TransactionViolation';
 
 export type {
     Account,
@@ -102,8 +107,11 @@ export type {
     Session,
     Task,
     Transaction,
+    TransactionViolation,
     User,
     UserWallet,
+    ViolationName,
+    ViolationType,
     WalletAdditionalDetails,
     WalletOnfido,
     WalletStatement,

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -42,6 +42,7 @@ import SecurityGroup from './SecurityGroup';
 import Session from './Session';
 import Task from './Task';
 import Transaction from './Transaction';
+import {TransactionViolation, ViolationName, ViolationType} from './TransactionViolation';
 import User from './User';
 import UserWallet from './UserWallet';
 import WalletAdditionalDetails from './WalletAdditionalDetails';
@@ -49,11 +50,6 @@ import WalletOnfido from './WalletOnfido';
 import WalletStatement from './WalletStatement';
 import WalletTerms from './WalletTerms';
 import WalletTransfer from './WalletTransfer';
-import {
-    TransactionViolation,
-    ViolationName,
-    ViolationType,
-} from './TransactionViolation';
 
 export type {
     Account,


### PR DESCRIPTION
This implements the ViolationUtils lib as requested in https://github.com/Expensify/App/issues/31083

Some notes on approach:

1. He asked for those `violationFields` and `formFields` objects, I think as a sort of hack to get some type checking and type safety. I replaced that with string literal union types and `Record`s  -- it's a more idiomatic way to do what he was trying to do, and I think will be better long-term. I [asked for his feedback on the approach here](https://github.com/Expensify/App/issues/31083#issuecomment-1817113219). I don't think he's a JS / TS dev so hopefully he finds this helpful, but if he doesn't like it, it'll be pretty easy to switch it back.

2. I had to add some stuff to `ONYXKEYS` and to `onyx/types` -- please take a look and let me know if anything seems like it's in completely the wrong place.

Otherwise should be pretty straightforward! 

This is a draft pending his approval of the approach, but would appreciate reviews so I can ship it as soon as he gives me the go-ahead.